### PR TITLE
Expose idType constructor on service

### DIFF
--- a/crud-service.js
+++ b/crud-service.js
@@ -30,6 +30,7 @@ module.exports = function CrudService(name, save, schema, options) {
     plural: plural,
     schema: schema,
     idProperty: save.idProperty,
+    idType: save.idType,
     create: function (object, validateOptions, callback) {
 
       if (typeof validateOptions === 'function') {


### PR DESCRIPTION
This is so that calling code can just lookup the service rather that both the service _and_ the persistence layer.

This:

``` js
var articleService = serviceLocator.articleService

new articleService.idType('515428002e906a2c84000001')
```

instead of this:

``` js
var ObjectId = serviceLocator.persistence('article')
  , articleService = serviceLocator.articleService

new ObjectId('515428002e906a2c84000001')
```
