### PR TITLE
Use ValidationError instead of Error

### DIFF
--- a/crud-service.js
+++ b/crud-service.js
@@ -51,7 +51,7 @@ module.exports = function CrudService(name, save, schema, options) {
             return callback(error)
           }
           if (Object.keys(validationErrors).length > 0) {
-            var validationError = new Error('Validation Error')
+            var validationError = new ValidationError()
             validationError.errors = validationErrors
             return callback(validationError, pipedObject)
           }
@@ -92,7 +92,7 @@ module.exports = function CrudService(name, save, schema, options) {
             return callback(error)
           }
           if (Object.keys(validationErrors).length > 0) {
-            var validationError = new Error('Validation Error')
+            var validationError = new ValidationError()
             validationError.errors = validationErrors
             return callback(validationError, pipedObject)
           }
@@ -147,7 +147,7 @@ module.exports = function CrudService(name, save, schema, options) {
               return callback(error)
             }
             if (Object.keys(validationErrors).length > 0) {
-              var validationError = new Error('Validation Error')
+              var validationError = new ValidationError()
               validationError.errors = validationErrors
               return callback(validationError, pipedObject)
             }
@@ -210,3 +210,12 @@ module.exports = function CrudService(name, save, schema, options) {
     }
   })
 }
+
+// Subclass of `Error`, but with problems: http://stackoverflow.com/a/871646
+function ValidationError(message) {
+  this.message = message;
+}
+
+ValidationError.prototype = Object.create(Error.prototype);
+ValidationError.prototype.name = 'ValidationError';
+ValidationError.prototype.constructor = ValidationError;

--- a/test/crud-service.test.js
+++ b/test/crud-service.test.js
@@ -116,6 +116,7 @@ describe('crud-service', function () {
           { name: 'Paul'
           , email: 'paul@serby.net'
           }, { persist: 'a' }, function (error) {
+            error.name.should.eql('ValidationError');
             error.errors.should.eql({ email: 'Email is required' })
             done()
           })
@@ -190,6 +191,7 @@ describe('crud-service', function () {
       it('should only validate tagged options', function (done) {
         service.create(
           {}, { validate: 'b' }, function (error) {
+            error.name.should.eql('ValidationError');
             error.errors.should.eql({ email: 'Email is required' })
             done()
           })
@@ -199,6 +201,7 @@ describe('crud-service', function () {
         service.create(
           { name: 'Paul'
           }, { persist: 'c' }, function (error) {
+            error.name.should.eql('ValidationError');
             error.errors.should.eql({ name: 'Name is required', email: 'Email is required' })
             done()
           })
@@ -320,6 +323,7 @@ describe('crud-service', function () {
           , name: 'Paul'
           , email: 'paul@serby.net'
           }, { persist: 'a' }, function (error) {
+            error.name.should.eql('ValidationError');
             error.errors.should.eql({ email: 'Email is required' })
             done()
           })
@@ -408,6 +412,7 @@ describe('crud-service', function () {
       it('should only validate tagged options', function (done) {
         service.create(
           {}, { validate: 'b' }, function (error) {
+            error.name.should.eql('ValidationError');
             error.errors.should.eql({ email: 'Email is required' })
             done()
           })
@@ -417,6 +422,7 @@ describe('crud-service', function () {
         service.create(
           { name: 'Paul'
           }, { persist: 'c' }, function (error) {
+            error.name.should.eql('ValidationError');
             error.errors.should.eql({ name: 'Name is required', email: 'Email is required' })
             done()
           })


### PR DESCRIPTION
Upon handling errors from crud-service, I want to know what type they are so I can choose how to deal with them. This was possible before by checking if `error.message === 'Validation Error'`, but I wasn't happy with this use of the error message.

With this change, I can instead check against the `name` property.
