### PR TITLE
Allowing options to not be defined when using update command...

### DIFF
--- a/crud-service.js
+++ b/crud-service.js
@@ -78,6 +78,11 @@ module.exports = function CrudService(name, save, schema, options) {
       })
     },
     update: function (object, updateOptions, callback) {
+      if (typeof updateOptions === 'function') {
+        callback = updateOptions
+        updateOptions = {}
+      }
+
       callback = callback || emptyFn
 
       var cleanObject = schema.cast(schema.stripUnknownProperties(schema.makeDefault(object), updateOptions.persist || updateOptions.tag, ignoreTagForSubSchema))

--- a/test/crud-service.test.js
+++ b/test/crud-service.test.js
@@ -301,6 +301,18 @@ describe('crud-service', function () {
 
     })
 
+    it('should use callback when no options are set', function (done) {
+
+      service.update(
+        { name: 'Paul Serby'
+        , email: 'paul@serby.net'
+        , _id: id
+        }, function () {
+          done()
+        })
+
+    })
+
     describe('options', function () {
       it('should only store and validate tagged options', function (done) {
         service.update(


### PR DESCRIPTION
setting them to {} by default. Adding associated tests.
