### PR TITLE
Pass back options to event listeners

### DIFF
--- a/crud-service.js
+++ b/crud-service.js
@@ -36,6 +36,7 @@ module.exports = function CrudService(name, save, schema, options) {
 
       if (typeof createOptions === 'function') {
         callback = createOptions
+        createOptions = {}
       }
 
       callback = callback || emptyFn
@@ -63,7 +64,7 @@ module.exports = function CrudService(name, save, schema, options) {
               if (error) {
                 return callback(error)
               }
-              self.emit('create', savedObject)
+              self.emit('create', savedObject, createOptions)
               callback(undefined, schema.stripUnknownProperties(savedObject))
             })
           })
@@ -109,7 +110,7 @@ module.exports = function CrudService(name, save, schema, options) {
               if (error) {
                 return callback(error)
               }
-              self.emit('update', savedObject)
+              self.emit('update', savedObject, updateOptions)
               if (!savedObject) return callback(undefined, undefined)
               callback(undefined, schema.stripUnknownProperties(savedObject))
             })
@@ -122,6 +123,7 @@ module.exports = function CrudService(name, save, schema, options) {
 
       if (typeof updateOptions === 'function') {
         callback = updateOptions
+        updateOptions = {}
       }
 
       if (!object[save.idProperty]) {
@@ -138,9 +140,10 @@ module.exports = function CrudService(name, save, schema, options) {
           return callback(new Error('Couldn\'t find object with an ' + save.idProperty + ' of ' + object[save.idProperty]))
         }
 
-        readObject = extend(readObject, object)
-
-        var cleanObject = schema.cast(schema.stripUnknownProperties(readObject, updateOptions.persist || updateOptions.tag))
+        // extend overrides the original object, the original readObject is still needed
+        var readObjectCloned = extend({}, readObject)
+          , updatedObject = extend(readObjectCloned, object)
+          , cleanObject = schema.cast(schema.stripUnknownProperties(updatedObject, updateOptions.persist || updateOptions.tag))
 
         pre.partialValidate.run(cleanObject, function (error, pipedObject) {
           if (error) {
@@ -169,7 +172,7 @@ module.exports = function CrudService(name, save, schema, options) {
                 if (error) {
                   return callback(error)
                 }
-                self.emit('partialUpdate', savedObject)
+                self.emit('partialUpdate', savedObject, readObject, updateOptions)
                 if (!savedObject) return callback(undefined, undefined)
                 callback(undefined, schema.stripUnknownProperties(savedObject))
               })
@@ -178,12 +181,17 @@ module.exports = function CrudService(name, save, schema, options) {
         })
       })
     },
-    'delete': function (id, callback) {
+    'delete': function (id, deleteOptions, callback) {
+      if (typeof deleteOptions === 'function') {
+        callback = deleteOptions
+        deleteOptions = {}
+      }
+
       save['delete'](id, function (error) {
         if (error) {
           return callback(error)
         }
-        self.emit('delete', id)
+        self.emit('delete', id, deleteOptions)
         if (typeof callback === 'function') callback()
       })
     },

--- a/test/crud-service.test.js
+++ b/test/crud-service.test.js
@@ -99,6 +99,36 @@ describe('crud-service', function () {
 
     })
 
+    it('should emit create with createOptions', function (done) {
+
+      service.on('create', function (obj, options) {
+        obj.name.should.equal('Paul Serby')
+        options.test.should.equal('Test')
+        done()
+      })
+
+      service.create(
+        { name: 'Paul Serby'
+        , email: 'paul@serby.net'
+        }, { test: 'Test' }, function () {})
+
+    })
+
+    it('should emit create with an empty createOptions if none defined', function (done) {
+
+      service.on('create', function (obj, options) {
+        obj.name.should.equal('Paul Serby')
+        should.deepEqual(options, {})
+        done()
+      })
+
+      service.create(
+        { name: 'Paul Serby'
+        , email: 'paul@serby.net'
+        }, function () {})
+
+    })
+
     describe('options', function () {
       it('should only store and validate tagged options', function (done) {
         service.create(
@@ -245,8 +275,8 @@ describe('crud-service', function () {
           service.read(newObject._id, function (error, object) {
             should.not.exist(error)
             should.not.exist(object.extraneous)
+            done()
           })
-          done()
         })
 
     })
@@ -301,6 +331,38 @@ describe('crud-service', function () {
 
     })
 
+    it('should emit update with updateOptions', function (done) {
+
+      service.on('update', function (obj, options) {
+        obj.name.should.equal('Paul Serby')
+        options.test.should.equal('Test')
+        done()
+      })
+
+      service.update(
+        { name: 'Paul Serby'
+        , email: 'paul@serby.net'
+        , _id: id
+        }, { test: 'Test' }, function () {})
+
+    })
+
+    it('should emit update with an empty updateOptions if none defined', function (done) {
+
+      service.on('update', function (obj, options) {
+        obj.name.should.equal('Paul Serby')
+        should.deepEqual(options, {})
+        done()
+      })
+
+      service.update(
+        { name: 'Paul Serby'
+        , email: 'paul@serby.net'
+        , _id: id
+        }, function () {})
+
+    })
+
     it('should use callback when no options are set', function (done) {
 
       service.update(
@@ -350,7 +412,7 @@ describe('crud-service', function () {
           })
       })
 
-      it('should store sub-schema properties regardless of tag if ignoreTagForSubSchemas is true', function(done) {
+      it('should store sub-schema properties regardless of tag if ignoreTagForSubSchemas is true', function (done) {
         //Set ignoreTagForSubSchema to true and set up initial object
         service = createContactCrudService(true)
         service.pre('update', function (object, cb) {
@@ -390,7 +452,7 @@ describe('crud-service', function () {
           })
       })
 
-      it('should store sub-schema properties with tag if ignoreTagForSubSchemas is false', function(done) {
+      it('should store sub-schema properties with tag if ignoreTagForSubSchemas is false', function (done) {
         service.update(
           { _id: id
           , name: 'Paul'
@@ -519,6 +581,38 @@ describe('crud-service', function () {
           should.not.exist(error)
           should.not.exist(object.extraneous)
         })
+    })
+
+    it('should emit partialUpdate with original object', function (done) {
+
+      service.on('partialUpdate', function (obj, originalObj) {
+        obj.name.should.equal('Paul Serby')
+        originalObj.name.should.equal('Paul')
+        done()
+      })
+
+      service.partialUpdate(
+        { name: 'Paul Serby'
+        , email: 'paul@serby.net'
+        , _id: id
+        }, function () {})
+
+    })
+
+    it('should emit partialUpdate with updateOptions', function (done) {
+
+      service.on('partialUpdate', function (obj, originalObj, options) {
+        obj.name.should.equal('Paul Serby')
+        options.test.should.equal('Test')
+        done()
+      })
+
+      service.partialUpdate(
+        { name: 'Paul Serby'
+        , email: 'paul@serby.net'
+        , _id: id
+        }, { test: 'Test' }, function () {})
+
     })
 
   })


### PR DESCRIPTION
This allows those listening to the service events to retrieve the
original options that were passed in during the operation

partialUpdate now returns the original object it's read from
