### PR TITLE
Returned object should be an instance of EventEmitter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - 6.0.0
   - 8.0.0
+  - 10.0.0

--- a/crud-service.js
+++ b/crud-service.js
@@ -8,7 +8,7 @@ const pipe = (pipeFns, initialValue, cb) => {
   const passThrough = callback => callback(null, initialValue)
   let fns
   if (pipeFns.size > 0) {
-    fns = [ passThrough, ...pipeFns ]
+    fns = [ passThrough ].concat(Array.from(pipeFns))
   } else {
     fns = [ passThrough ]
   }
@@ -134,7 +134,7 @@ module.exports = (name, save, schema, options) => {
         }
 
         // extend overrides the original object, the original readObject is still needed
-        const updatedObject = { ...clone(readObject), ...clone(object) }
+        const updatedObject = Object.assign({}, clone(readObject), clone(object))
         const cleanObject = schema.cast(schema.stripUnknownProperties(updatedObject, updateOptions.persist || updateOptions.tag))
         pipe(pre.partialValidate, cleanObject, (error, pipedObject) => {
           if (error) return callback(error)

--- a/crud-service.js
+++ b/crud-service.js
@@ -1,6 +1,5 @@
-
 const { waterfall } = require('async')
-const events = require('events')
+const { EventEmitter } = require('events')
 const stream = require('stream')
 const clone = require('lodash.clone')
 const emptyFn = () => {}
@@ -20,7 +19,7 @@ module.exports = (name, save, schema, options) => {
   const slug = (options && options.slug) ? options.slug : name.toLowerCase().replace(/ /g, '')
   const plural = (options && options.plural) ? options.plural : `${name}s`
   const properties = schema.getProperties()
-  const self = new events.EventEmitter()
+  const self = new EventEmitter()
   const ignoreTagForSubSchema = (options && options.ignoreTagForSubSchema) ? options.ignoreTagForSubSchema : false
 
   const pre = {
@@ -37,7 +36,7 @@ module.exports = (name, save, schema, options) => {
     throw new Error(`schema does not have the required property '${save.idProperty}'`)
   }
 
-  return {
+  return Object.assign(self, {
     on: self.on.bind(self),
     emit: self.emit.bind(self),
     name,
@@ -210,5 +209,5 @@ module.exports = (name, save, schema, options) => {
     pre (method, processor) {
       return pre[method].add(processor)
     }
-  }
+  })
 }

--- a/test/crud-service.test.js
+++ b/test/crud-service.test.js
@@ -4,6 +4,7 @@ const emptyFn = () => {}
 const required = require('validity-required')
 const schemata = require('schemata')
 const stream = require('stream')
+const { EventEmitter } = require('events')
 
 const fixtures = {
   contact: {
@@ -65,6 +66,12 @@ function createContactCrudService (ignoreTagForSubSchema) {
 }
 
 describe('crud-service', () => {
+  describe('returned object', () => {
+    it('should expose an object with the EventEmitter API', () => {
+      const service = createContactCrudService()
+      expect(service).toBeInstanceOf(EventEmitter)
+    })
+  })
   describe('create()', () => {
     let service
 

--- a/test/crud-service.test.js
+++ b/test/crud-service.test.js
@@ -523,7 +523,7 @@ describe('crud-service', () => {
 
       service.partialUpdate(partial, (error, updatedObject) => {
         expect(error).toBeFalsy()
-        expect(updatedObject).toEqual({ ...fixtures.contact, ...partial })
+        expect(updatedObject).toEqual(Object.assign({}, fixtures.contact, partial))
         done()
       })
     })
@@ -545,7 +545,7 @@ describe('crud-service', () => {
       })
       service.partialUpdate(partial, (error, updatedObject) => {
         expect(error).toBeFalsy()
-        expect(updatedObject).toEqual({ ...fixtures.contact, ...partial, ...{ name: 'SERBY' } })
+        expect(updatedObject).toEqual(Object.assign({}, fixtures.contact, partial, { name: 'SERBY' }))
         done()
       })
     })


### PR DESCRIPTION
This allows functions such as:
```
service.removeAllListeners()
service.once(...)
service.listeners()
...etc
```
From the EventEmitter API to be accessed.

+ fixes Travis CI